### PR TITLE
fix: cli commands are supplied separately

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,4 @@ COPY --from=builder /app/package*.json ./
 RUN npm ci --omit=dev --ignore-scripts
 
 # Run the CLI
-ENTRYPOINT ["node", "dist/cli.js", "--loop", "1000", "hash", "Hello Cryptobroker!"]
+ENTRYPOINT ["node", "dist/cli.js"]


### PR DESCRIPTION
## Description
Dockerfile should not loop automatically and respective commands are given separately.

## Type of change
- [x] Bug fix
- [ ] Addition of feature
- [ ] Breaking change (Bug or New feature that would cause existing functionality/consumers to not work as expected. Reviewers might change this.)
- [ ] None of the above (Reviewers might ask for more clarification.)

## Checklist:
- [x] Supplied as many details as possible on this change
- [x] The code is easy to read and maintainable by others
- [ ] Corresponding changes to the documentation has been done (N.A.)
- [x] Already existing and new unit tests were added and pass locally
