### PR TITLE
refactor: Adjust sign certificate task for new CSR and CA cert

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -104,7 +104,7 @@ tasks:
         TEST_CSR_DIR=../crypto-broker-deployment/testing/certificates/test-csr
         rm -rf $TMP_DIR
         mkdir -p $TMP_DIR
-        SIGNED_CERTIFICATE=$(node ./dist/cli.js --profile=Default sign --csr=$TEST_CSR_DIR/test-client.csr --caCert=$TEST_CA_DIR/root-CA-ecdsa.pem --caKey=$TEST_CA_DIR/root-CA-ecdsa-private-key.pem | {{.GREP_CMD}} -oP '\"signedCertificate\":\s?"\K[^"]+')
+        SIGNED_CERTIFICATE=$(node ./dist/cli.js --profile=Default sign --csr=$TEST_CSR_DIR/csr-nist-secp384r1.csr --caCert=$TEST_CA_DIR/cert-test-CA-nist-secp521r1.pem --caKey=$TEST_CA_DIR/test-CA-nist-secp521r1.pem | {{.GREP_CMD}} -oP '\"signedCertificate\":\s?"\K[^"]+')
         printf "$SIGNED_CERTIFICATE" > $TMP_DIR/cert-response.pem
         openssl x509 -inform PEM -in $TMP_DIR/cert-response.pem -text
 


### PR DESCRIPTION
## Description
Adjust the sign certificate task in Taskfile for new CSR and CA certificate. Merge after the deployment PR is merged.

## Type of change
- [ ] Bug fix
- [ ] Addition of feature
- [ ] Breaking change (Bug or New feature that would cause existing functionality/consumers to not work as expected. Reviewers might change this.)
- [x] None of the above (Reviewers might ask for more clarification.)

## Checklist:
- [x] Supplied as many details as possible on this change
- [x] The code is easy to read and maintainable by others
- [ ] Corresponding changes to the documentation has been done
- [ ] Already existing and new unit tests were added and pass locally
