### PR TITLE
feat: Use hash tagged actions, fix lint issues

### DIFF
--- a/.github/workflows/md.yml
+++ b/.github/workflows/md.yml
@@ -5,14 +5,18 @@ on:
   push:
     branches: [ main ]
 
+permissions: {}
+
 jobs:
   markdownlint-pipeline:
+    permissions: {}
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
           fetch-depth: 0 # important for git diff comparisons
+          persist-credentials: false
 
     - name: Run Markdownlint
-      uses: open-crypto-broker/.github/actions/markdownlint@main
+      uses: open-crypto-broker/.github/actions/markdownlint@main # nolint # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -16,9 +16,14 @@ on:
         type: string
         default: "."
 
+permissions: {}
+
 jobs:
   scan:
-    uses: open-crypto-broker/.github/.github/workflows/security-scan.yaml@main
+    permissions:
+      security-events: write
+      contents: read
+    uses: open-crypto-broker/.github/.github/workflows/security-scan.yaml@main # nolint # zizmor: ignore[unpinned-uses]
     with:
       scan_directory: ${{ inputs.scan_directory || true }}
       directory_to_scan: ${{ inputs.directory_to_scan || '.' }}

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -5,23 +5,32 @@ on:
     branches: [main]
   pull_request:
 
+permissions: {}
+
 jobs:
   build-and-test:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
-    container:
-        image: node:24
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: 'package.json'
+          cache: npm
+
       - name: Install Task
-        uses: go-task/setup-task@v2
+        uses: go-task/setup-task@3be4020d41929789a01026e0e427a4321ce0ad44 # v2.0.0
         with:
           version: '3.x'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          submodules: recursive
 
       - name: Run CI task from Taskfile (continuous integration)
         run: task ci

--- a/.github/workflows/npm-version-bump.yml
+++ b/.github/workflows/npm-version-bump.yml
@@ -15,28 +15,30 @@ on:
           - prerelease
           - release
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   bump-version:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     environment: DEPLOYMENT
     steps:
       - name: create github token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         id: app-token
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.DEPLOYMENT_SECRET }}
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - name: Run version bump
-        uses: open-crypto-broker/.github/actions/npm-version-bump@main
+        uses: open-crypto-broker/.github/actions/npm-version-bump@main # nolint # zizmor: ignore[unpinned-uses]
         with:
           version: ${{ inputs.version }}

--- a/.github/workflows/release-changelog.yaml
+++ b/.github/workflows/release-changelog.yaml
@@ -4,32 +4,47 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'New version (e.g. 1.3.0)'
-        required: true
+        description: 'New version (e.g. 1.3.0) — leave empty to read from package.json'
+        required: false
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   changelog:
     name: Update changelog
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     environment: DEPLOYMENT
     steps:
-      - uses: actions/create-github-app-token@v3
+      - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         id: app-token
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.DEPLOYMENT_SECRET }}
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
+
+      - name: Resolve version
+        id: resolve-version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [ -n "$INPUT_VERSION" ]; then
+            echo "version=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
+          else
+            VERSION=$(jq -r '.version' package.json)
+            echo "Resolved version from package.json: $VERSION"
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Use git-cliff for changelog generation, create git tag, push to repo
-        uses: open-crypto-broker/.github/actions/git-cliff@main
+        uses: open-crypto-broker/.github/actions/git-cliff@main # nolint # zizmor: ignore[unpinned-uses]
         with:
           REF_NAME: ${{ github.ref_name }}
-          VERSION: ${{ github.event.inputs.version }}
+          VERSION: ${{ steps.resolve-version.outputs.version }}

--- a/.github/workflows/release-npmjs.yml
+++ b/.github/workflows/release-npmjs.yml
@@ -2,23 +2,25 @@ name: Publish Package to npmjs
 on:
   workflow_dispatch:
 
-permissions:
-  contents: read
-  id-token: write
+permissions: {}
 
 jobs:
   publish:
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: '24'
+          node-version-file: 'package.json'
           registry-url: 'https://registry.npmjs.org/'
 
       - name: Install dependencies
@@ -27,4 +29,4 @@ jobs:
 
         run: npm publish --provenance --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} # zizmor: ignore[secrets-outside-env]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,62 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions: {}
+
+jobs:
+  github-release:
+    name: Create GitHub Release
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Extract release notes from CHANGELOG.md
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          VERSION="${TAG#v}"
+          awk -v ver="$VERSION" '
+            /^## \[/ { if (found) exit; if (index($0, "[" ver "]")) found=1; next }
+            found { print }
+          ' CHANGELOG.md > release-notes.md
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: gh release create "$TAG" --verify-tag -F release-notes.md
+
+  publish-npm:
+    name: Publish to npmjs
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0 # zizmor: ignore[cache-poisoning]
+        with:
+          node-version-file: 'package.json'
+          registry-url: 'https://registry.npmjs.org/'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish package
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} # zizmor: ignore[secrets-outside-env]

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
   "bugs": {
     "url": "https://github.com/open-crypto-broker/crypto-broker-client-js.git"
   },
+  "engines": {
+    "node": ">=24"
+  },
   "license": "Apache-2.0",
   "description": "Client Javascript repository to interact with a deployed Crypto Broker Server",
   "repository": {


### PR DESCRIPTION
## Description
Change actions to hash tagged versions.
Use Node version specified in the package.json file. With that we have only one point where to set the Node.js version.
Fix lint issues.
Automatically retrieve version number for changelog generation from package.json file, or set it manually.
Add new release workflow to automatically create a release after the changelog was generated.
Extract the changes from changelog to the release notes in GitHub release page and in a second step push to npmjs.

## Type of change
- [ ] Bug fix
- [x] Addition of feature
- [ ] Breaking change (Bug or New feature that would cause existing functionality/consumers to not work as expected. Reviewers might change this.)
- [ ] None of the above (Reviewers might ask for more clarification.)

## Checklist:
- [x] Supplied as many details as possible on this change
- [x] The code is easy to read and maintainable by others
- [ ] Corresponding changes to the documentation has been done
- [ ] Already existing and new unit tests were added and pass locally
